### PR TITLE
Added support for org-mode sync.

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -19,6 +19,7 @@ ACTIONS
 *help*:: show usage information
 *version*:: show version information
 *orgmode*:: print all reminder lists with org-mode friendly syntax. accepts output file as parameter
+*parseorg*:: syncs an org-mode json export with reminder event store
 
 BUILD
 -----

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -17,7 +17,8 @@ ACTIONS
 *cat*:: show reminder detail
 *done*:: mark reminder as complete
 *help*:: show usage information
-*verison*:: show version information
+*version*:: show version information
+*orgmode*:: print all reminder lists with org-mode friendly syntax. accepts output file as parameter
 
 BUILD
 -----

--- a/rem/main.m
+++ b/rem/main.m
@@ -481,9 +481,22 @@ static void printOrgMode()
 
                 [fileHandle writeData:[[NSString stringWithFormat:@":LOGBOOK:\nAPPLE_REM_ID: %@\n:END:\n", reminder.calendarItemIdentifier] dataUsingEncoding:NSUTF8StringEncoding]];
 
-                if (reminder.completed) {
-                   [fileHandle writeData:[[NSString stringWithFormat: @"CLOSED: [%@]\n", [dateFormatter stringFromDate:reminder.completionDate]] dataUsingEncoding:NSUTF8StringEncoding]];
+                 if (reminder.completed) {
+                   [fileHandle writeData:[[NSString stringWithFormat: @"CLOSED: [%@] ", [dateFormatter stringFromDate:reminder.completionDate]] dataUsingEncoding:NSUTF8StringEncoding]];
                 }
+
+                 NSArray *alarms = reminder.alarms;
+
+                 for(NSUInteger j = 0; j < alarms.count; j++)
+                 {
+                     EKAlarm *alarm = [alarms objectAtIndex:j];
+                     NSDate *dueDate = alarm.absoluteDate;
+                    
+                     if (dueDate) {
+                         [fileHandle writeData:[[NSString stringWithFormat: @"SCHEDULED: <%@>\n", [dateFormatterSchedule stringFromDate:dueDate]] dataUsingEncoding:NSUTF8StringEncoding]];
+                     }
+                 }
+
 
                 [fileHandle writeData:[[NSString stringWithFormat:@"Created: [%@]\n", [dateFormatter stringFromDate:reminder.creationDate]] dataUsingEncoding:NSUTF8StringEncoding]];
 
@@ -494,19 +507,6 @@ static void printOrgMode()
                 NSDate *startDate = [reminder.startDateComponents date];
                 if (startDate) {
                     [fileHandle writeData:[[NSString stringWithFormat: @"Started On: [%@]\n", [dateFormatter stringFromDate:startDate]] dataUsingEncoding:NSUTF8StringEncoding]];
-                }
-
-                //NSDate *dueDate = [reminder.dueDateComponents date];
-                NSArray *alarms = reminder.alarms;
-
-                for(NSUInteger j = 0; j < alarms.count; j++)
-                {
-                    EKAlarm *alarm = [alarms objectAtIndex:j];
-                    NSDate *dueDate = alarm.absoluteDate;
-                    
-                    if (dueDate) {
-                        [fileHandle writeData:[[NSString stringWithFormat: @"SCHEDULED: <%@>\n", [dateFormatterSchedule stringFromDate:dueDate]] dataUsingEncoding:NSUTF8StringEncoding]];
-                    }
                 }
 
                 if (reminder.hasNotes) {

--- a/scripts/org-export-json.el
+++ b/scripts/org-export-json.el
@@ -1,0 +1,27 @@
+;; Provides function to export current org buffer as JSON structure
+;; to $file.org.json. Adapted from an org-mode mailing post by
+;; Brett Viren: https://lists.gnu.org/archive/html/emacs-orgmode/2014-01/msg00338.html
+(require 'json)
+(defun org-export-json ()
+  (interactive)
+  (let* ((tree (org-element-parse-buffer 'object nil)))
+    (org-element-map tree (append org-element-all-elements
+                                  org-element-all-objects '(plain-text))
+      (lambda (x)
+        (if (org-element-property :parent x)
+            (org-element-put-property x :parent "none"))
+        (if (org-element-property :structure x)
+            (org-element-put-property x :structure "none"))
+        ))
+    (write-region
+     (json-encode tree)
+     nil (concat (buffer-file-name) ".json"))))
+
+(defun cli-org-export-json ()
+  (let ((org-file-path (car command-line-args-left))
+        (other-load-files (cdr command-line-args-left)))
+    (mapc 'load-file other-load-files)
+    (find-file org-file-path)
+    (org-mode)
+    (message "Exporting to JSON: %s" (car command-line-args-left))
+    (org-export-json)))


### PR DESCRIPTION
I added support for an org-mode friendly output of rem. 

I tried adding all features which were discussed in #7 . The command "orgmode" prints an orgmode file into standard output. When adding an additional argument, you can specify an output file (e.g. "rem orgmode ./reminder.org").

It is based on previous ls/cat commands. Additionally, I added priority, alarms and printing the unique-identifier of the reminder (albeit, not really useful right now as no command accepts it as input, maybe useful for future).

Things not taken care of:
- Location based alarms
- Repeating alarms
